### PR TITLE
Add wordpress com support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ Setup the url to your WP blog in your env file:
 WP_TO_LARAVEL_API_URL=https://blog.your-blog-domain.com/
 ```
 
+If you are using wordpress.com to host your blog, set the following env variable to true (default is false). This is done because wordpress.com and wordpress.org (self hosted instances) have different url structure when fetching the posts
+``` env
+WP_TO_LARAVEL_IS_WORDPRESS_COM=true
+```
+
 Finally, we need to configure WP itself. If you're using Wordpress 4.7+, then you're all set - crack on! Otherwise, you'll need to install the WP API plugin to the WP site you wish to sync from:
 
 [Wordpress API](http://v2.wp-api.org/)

--- a/README.md
+++ b/README.md
@@ -37,15 +37,20 @@ Migrate your database to setup the posts, categories, tags & author tables:
 $ php artisan migrate
 ```
 
-Setup the url to your WP blog in your env file:
+If you are using wordpress.com to host your blog, set the following env variable to true (default is false). This is done because wordpress.com and wordpress.org (self hosted instances) have different url structure when fetching the posts
+``` env
+WP_TO_LARAVEL_IS_WORDPRESS_COM=true
+```
+
+Next, add your WP blog url to the env file
 
 ``` env
 WP_TO_LARAVEL_API_URL=https://blog.your-blog-domain.com/
 ```
 
-If you are using wordpress.com to host your blog, set the following env variable to true (default is false). This is done because wordpress.com and wordpress.org (self hosted instances) have different url structure when fetching the posts
+or for wordpress.com hosted blogs (change the your-blog part of the url)
 ``` env
-WP_TO_LARAVEL_IS_WORDPRESS_COM=true
+WP_TO_LARAVEL_API_URL=https://public-api.wordpress.com/wp/v2/sites/your-blog.wordpress.com/
 ```
 
 Finally, we need to configure WP itself. If you're using Wordpress 4.7+, then you're all set - crack on! Otherwise, you'll need to install the WP API plugin to the WP site you wish to sync from:

--- a/config/config.php
+++ b/config/config.php
@@ -10,10 +10,23 @@ return [
     | This is the url of your blog where you've installed the Wordpress API
     | plugin.
     |
-    | e.g. http://blog.example.dev/
+    | e.g. http://blog.example.dev/ or https://coolname.wordpress.com/
 	*/
     'api_url'        => env('WP_TO_LARAVEL_API_URL'),
 
+    /*
+	|--------------------------------------------------------------------------
+	| IS WORDPRESS COM
+	|--------------------------------------------------------------------------
+    |
+    | Is your site hosted on wordpress.com
+    | There are two types of wordpress, wordpress.com which hosts the blog, or
+    | wordpress.org which is self hosted
+    | This matters because they have differnt urls for the API
+    |
+    | e.g. true (defaults false)
+    */
+    'is_wordpress_com'  => env('WP_TO_LARAVEL_IS_WORDPRESS_COM', false),
 
     /*
 	|--------------------------------------------------------------------------

--- a/src/WordpressToLaravel.php
+++ b/src/WordpressToLaravel.php
@@ -18,7 +18,7 @@ class WordpressToLaravel
     /**
      * @var string
      */
-    protected $endpoint = 'wp-json/wp/v2/';
+    protected $hostedEndpoint = 'wp-json/wp/v2/';
 
     /**
      * @var FractalManager
@@ -92,6 +92,11 @@ class WordpressToLaravel
         $this->postModel = $this->config['post_model'] ?? Post::class;
         $this->categoryModel = $this->config['category_model'] ?? Category::class;
         $this->authorModel = $this->config['author_model'] ?? Author::class;
+    }
+
+    protected function isWordpressCom()
+    {
+        return $this->config['is_wordpress_com'];
     }
 
     protected function setupTransformers()
@@ -202,7 +207,7 @@ class WordpressToLaravel
         return sprintf(
             '%s%s%s',
             Str::finish($this->config['api_url'], '/'),
-            $this->endpoint,
+            $this->isWordpressCom() ? '' : $this->hostedEndpoint,
             $queryString
         );
     }


### PR DESCRIPTION
Adds support for blogs on wordpress.com

Wordpress.com hosted sites have a different url for the posts api so added a flag (that is default false so wont cause issues upgrading) and added some info to readme